### PR TITLE
Add name to generated users

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ async function clientLoop(i) {
 async function clientSetup(i) {
   const user = {
     id: `${userIDPrefix}${i}`,
+    name: `${userIDPrefix}${i}`
   };
   const token = serverSideClient.createToken(user.id);
   const client = new StreamChat(apiKey, { allowServerSideConnect: true });

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ function sleep(ms) {
 async function clientLoop(i) {
   const user = {
     id: `${userIDPrefix}${i}`,
+    name: `${userIDPrefix}${i}`
   };
   const client = new StreamChat(apiKey, { allowServerSideConnect: true });
   const token = serverSideClient.createToken(user.id);


### PR DESCRIPTION
This will be useful to test searching for 100+ members in a channel. Currently the generated users only have IDs, so it is not possbile to use it for searching users in composer mentions